### PR TITLE
Fix typo in JdbcAnonymizerServiceTest

### DIFF
--- a/src/test/java/com/rolfje/anonimatron/jdbc/JdbcAnonymizerServiceTest.java
+++ b/src/test/java/com/rolfje/anonimatron/jdbc/JdbcAnonymizerServiceTest.java
@@ -53,7 +53,7 @@ public class JdbcAnonymizerServiceTest extends AbstractInMemoryHsqlDbTest {
                 getIntResult("select count(*) from TABLE1 where COL1 like 'varcharstring%'"));
 
         assertEquals(
-                "Rows dissapeared from the data set.",
+                "Rows disappeared from the data set.",
                 100,
                 getIntResult("select count(*) from TABLE1 where COL1 not like 'varcharstring%'"));
     }


### PR DESCRIPTION
## Summary
- correct spelling of 'disappeared' in JdbcAnonymizerServiceTest

## Testing
- `mvn -q test-compile` *(fails: mvn not found)*